### PR TITLE
Published svg.shapes.js@0.0.1 to npm

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2012-2014 Wout Fierens
+http://svgjs.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name":         "svg.shapes.js"
+, "description":  "A shapes plugin for the svg.js library"
+, "url":          "https://github.com/wout/svg.shapes.js"
+, "homepage":     "http://svgjs.com"
+, "keywords":     ["svg", "shapes", "vector", "graphics", "animation"]
+, "author":       "Wout Fierens <wout@impinc.co.uk>"
+, "main":         "svg.shapes.js"
+, "version":      "0.0.1"
+, "maintainers": [
+    {
+      "name":     "Wout Fierens"
+    , "email":    "wout@woutfierens.com"
+    , "web":      "http://woutfierens.com"
+    }
+  ]
+, "licenses": [
+    {
+      "type":     "MIT"
+    , "url":      "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ]
+, "repositories": [
+    {
+      "type":     "git"
+    , "url":      "https://github.com/wout/svg.shapes.js.git"
+    }
+  ]
+, "github":       "https://github.com/wout/svg.shapes.js"
+}


### PR DESCRIPTION
Published svg.shapes.js@0.0.1 to npm, thanks.  Added `package.json` and `MIT-LICENSE` (mostly cloned from `svg.js` repo). cc @wout 
